### PR TITLE
make mirror handle all hg branches

### DIFF
--- a/handle_mirror_webhook.py
+++ b/handle_mirror_webhook.py
@@ -54,11 +54,18 @@ def sync_repos():
             print('pushing to %s on branch %s' % (
                 LOCAL_GIT_REPO_PATH, git_branch))
             repo.push(LOCAL_GIT_REPO_PATH, bookmark=git_branch)
+        # ensure tags are pushed
+        print('pushing to %s' % LOCAL_GIT_REPO_PATH)
+        repo.push(LOCAL_GIT_REPO_PATH)
 
     with git.Repo(LOCAL_GIT_REPO_PATH) as repo:
-        print('pushing to %s from %s' % (GH_REPO, LOCAL_GIT_REPO_PATH))
-        repo.remotes.origin.push(all=True)
+        for git_branch in GIT_BRANCH_MAP.values():
+            print('pushing to %s from %s on branch %s' % (
+                GH_REPO, LOCAL_GIT_REPO_PATH, git_branch))
+            repo.remotes.origin.push(git_branch)
+        print('pushing tags to %s from %s' % (GH_REPO, LOCAL_GIT_REPO_PATH))
         repo.remotes.origin.push(tags=True)
+    print('Done!')
 
 
 class MainHandler(RequestHandler):


### PR DESCRIPTION
This makes the mirror bot handle our current branching scheme, preserving the branch names (except for renaming "yt" to "master"). It also makes the mirroring target github.com/yt-project/yt (i.e. that repo should be created before this is merged). If anyone thinks we should hold off on creating the final repo I can revert that to point at `yt-test`.

I've added some print statements which were helpful for me to gauge progress during debugging. Let me know if I should remove them or convert them to logging events.

I did a fair amount of refactoring to get this to work cleanly. In particular, I removed the step where we were creating a temporary git repo and just used the `LOCAL_GIT_REPO` to push to github. Let me know if that breaks the mirroring on the real setup.